### PR TITLE
Secures Spotify refresh tokens and increases storage capacity

### DIFF
--- a/app/models/user_model.py
+++ b/app/models/user_model.py
@@ -24,7 +24,7 @@ class User(db.Model):
     # Credentials Spotify propres à l’utilisateur
     spotify_client_id = db.Column(db.String(255))
     spotify_client_secret = db.Column(db.String(255))
-    spotify_refresh_token = db.Column(db.String(512))
+    spotify_refresh_token = db.Column(db.String(1024))
 
     # Préférences d'affichage
     default_color_hex = db.Column(db.String(7))  # format normalisé '#rrggbb'

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -81,13 +81,15 @@ class UserService:
         user = self.get_user(username)
         if not user:
             return False
-        user.spotify_refresh_token = refresh_token
+        # Chiffrer le refresh token avant stockage (None reste None)
+        user.spotify_refresh_token = encrypt_str(refresh_token)
         db.session.commit()
         return True
 
     def get_refresh_token(self, username: str) -> Optional[str]:
         u = self.get_user(username)
-        return u.spotify_refresh_token if u else None
+        # Déchiffrer si préfixé enc:, sinon retourne la valeur legacy en clair
+        return decrypt_str(u.spotify_refresh_token) if u else None
 
     # Préférences: couleur par défaut (format '#rrggbb')
     def set_default_color(self, username: str, color_hex: Optional[str]) -> bool:

--- a/migrations/versions/f1a2b3c4d5e6_increase_refresh_token_len.py
+++ b/migrations/versions/f1a2b3c4d5e6_increase_refresh_token_len.py
@@ -1,0 +1,36 @@
+"""increase spotify_refresh_token length to 1024
+
+Revision ID: f1a2b3c4d5e6
+Revises: d4f1a2b3c6e7
+Create Date: 2025-08-30 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "f1a2b3c4d5e6"
+down_revision = "d4f1a2b3c6e7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.alter_column(
+            "spotify_refresh_token",
+            type_=sa.String(length=1024),
+            existing_type=sa.String(length=512),
+            existing_nullable=True,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.alter_column(
+            "spotify_refresh_token",
+            type_=sa.String(length=512),
+            existing_type=sa.String(length=1024),
+            existing_nullable=True,
+        )


### PR DESCRIPTION
Enhances the security and usability of Spotify integration:
- Encrypts stored Spotify refresh tokens to protect sensitive user data.
- Adjusts database schema to increase `spotify_refresh_token` storage length from 512 to 1024 characters, accommodating longer token values.

Includes a database migration script to seamlessly apply these changes.

Benefits:
- Improves security by ensuring sensitive tokens are stored in an encrypted format.
- Prevents potential truncation or data loss for longer Spotify refresh tokens.

Relates to improved user data security best practices.